### PR TITLE
Make primary term ID column key filterable

### DIFF
--- a/includes/ahw-content.php
+++ b/includes/ahw-content.php
@@ -1348,8 +1348,9 @@ class Akka_headless_wp_content
             return null;
         }
         if (count($terms) > 1 && function_exists('yoast_get_primary_term_id')) {
+            $term_id_column_key = apply_filters('ahw_primary_term_id_column_key', 'id');
             $term_id = yoast_get_primary_term_id($taxonomy, $post);
-            $term_index = array_search($term_id, array_column($terms, 'id'));
+            $term_index = array_search($term_id, array_column($terms, $term_id_column_key));
             if ($term_index !== false) {
                 return $terms[$term_index];
             }


### PR DESCRIPTION
Introduces the 'ahw_primary_term_id_column_key' filter to allow customization of the term ID column key when searching for the primary term.

### Bakgrund
På SNS sätts inte `primary_term` korrekt, det blir alltid den term som ligger överst i `terms`.

### Lösning
När `$term_index` sätts ska `column_key` vara `term_id` istället för `id`. Det kan nu ändras via ett filter för att fortfarande fungera i projekt där `id` behöver användas som `column_key`. Om funktionen inte fungerat sedan tidigare kan `column_key` sättas till `term_id` direkt, så skipper vi möjligheten att ändra via filter.

### Exempel för lösning med filter
Sätt column_key i temat via:
```php
add_filter('ahw_primary_term_id_column_key', function ($key) {
  return 'term_id';
});
```