### PR TITLE
Guard Term::get_url() against WP_Error from get_term_link()

### DIFF
--- a/akka-headless-wp.php
+++ b/akka-headless-wp.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/aventyret/akka-wp/blob/main/plugins/akka-headless
 Description: Use Wordpress as a headless CMS, with Gutenberg as the content provider
 Author: Mediakooperativet, Äventyret
 Author URI: https://aventyret.com
-Version: 2.5.2
+Version: 2.5.3
 */
 
 if (basename($_SERVER['PHP_SELF']) == basename(__FILE__)){

--- a/includes/akka-term.php
+++ b/includes/akka-term.php
@@ -80,7 +80,13 @@ class Term
 
     public static function get_url($term_id)
     {
-        return Utils::parse_url(str_replace(WP_HOME, '', get_term_link($term_id)));
+        $term_link = get_term_link($term_id);
+        // get_term_link() returns a WP_Error for a missing/invalid term id;
+        // passing that to str_replace() is a fatal TypeError.
+        if (is_wp_error($term_link)) {
+            return null;
+        }
+        return Utils::parse_url(str_replace(WP_HOME, '', $term_link));
     }
 
     public static function get_seo_meta($term_data)


### PR DESCRIPTION
## Problem

`Term::get_url()` passes `get_term_link($term_id)` straight into `str_replace()`. For a missing or invalid term id, `get_term_link()` returns a `WP_Error`, and `str_replace()` then throws a fatal `TypeError` (argument #3 must be `array|string`, `WP_Error` given).

This crashes the entire request whenever a consumer resolves a url from a stale/deleted term id — e.g. a hand-picked taxonomy item stored in a block whose term was later removed.

## Fix

Return `null` when `get_term_link()` yields a `WP_Error`.

Version bumped 2.5.2 → 2.5.3.

## Context

Surfaced while debugging a production hang in a consumer site (Byggföretagen BUC). The hang root cause was elsewhere (a page-blurb → `get_single` render loop in the theme), but this `WP_Error` path is a latent fatal in the package that the same data exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)